### PR TITLE
feat: adicionar documentação Swagger e ajustar retorno da listagem de…

### DIFF
--- a/app/Http/Controllers/AppointmentsController.php
+++ b/app/Http/Controllers/AppointmentsController.php
@@ -9,7 +9,62 @@ use Illuminate\Http\JsonResponse;
 class AppointmentsController extends Controller
 {
     /**
-     * Store a newly created resource in storage.
+     * @OA\Post(
+     *     path="/api/medicos/consulta",
+     *     summary="Criar um novo agendamento de consulta",
+     *     description="Agendar uma nova consulta para um médico e paciente em uma determinada data.",
+     *     tags={"Médicos"},
+     *     security={{"bearerAuth":{}}},
+     *
+     *     @OA\RequestBody(
+     *         required=true,
+     *
+     *         @OA\JsonContent(
+     *             required={"medico_id", "paciente_id", "data"},
+     *
+     *             @OA\Property(property="medico_id", type="integer", example=1),
+     *             @OA\Property(property="paciente_id", type="integer", example=5),
+     *             @OA\Property(property="data", type="string", format="date-time", example="2025-02-08 14:00:00")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=201,
+     *         description="Consulta agendada com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="id", type="integer", example=10),
+     *             @OA\Property(property="medico_id", type="integer", example=1),
+     *             @OA\Property(property="paciente_id", type="integer", example=5),
+     *             @OA\Property(property="data", type="string", format="date-time", example="2025-02-03T14:00:00"),
+     *             @OA\Property(property="created_at", type="string", format="date-time", example="2025-02-03T12:00:00"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time", example="2025-02-03T12:00:00"),
+     *             @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null)
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=422,
+     *         description="Erro - Médico já tem uma consulta agendada neste horário",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Este médico já tem uma consulta agendada neste horário.")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro interno no servidor ao tentar criar a consulta",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao agendar consulta."),
+     *             @OA\Property(property="error", type="string", example="Detalhes do erro interno")
+     *         )
+     *     )
+     * )
      */
     public function store(StoreAppointmentRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -6,8 +6,63 @@ use Illuminate\Http\Request;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
+/**
+ * @OA\Tag(
+ *     name="Autenticação",
+ *     description="Endpoints para autenticação de usuários utilizando JWT"
+ * )
+ */
 class AuthController extends Controller
 {
+    /**
+     * @OA\Post(
+     *     path="/api/login",
+     *     summary="Autenticar um usuário",
+     *     description="Realiza a autenticação do usuário e retorna um token JWT.",
+     *     tags={"Autenticação"},
+     *
+     *     @OA\RequestBody(
+     *         required=true,
+     *
+     *         @OA\JsonContent(
+     *             required={"email", "password"},
+     *
+     *             @OA\Property(property="email", type="string", format="email", example="christian.ramires@example.com"),
+     *             @OA\Property(property="password", type="string", format="password", example="password")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Usuário autenticado com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="token", type="string", example="eyJhbGciOiJIUzI1NiIsInR5cCI...")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=401,
+     *         description="Credenciais inválidas",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="error", type="string", example="Invalid credentials")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao criar token",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="error", type="string", example="Could not create token")
+     *         )
+     *     )
+     * )
+     */
     public function login(Request $request)
     {
         $credentials = $request->only('email', 'password');
@@ -25,6 +80,49 @@ class AuthController extends Controller
         }
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/user",
+     *     summary="Obter informações do usuário autenticado",
+     *     description="Retorna os dados do usuário autenticado com base no token JWT fornecido.",
+     *     tags={"Autenticação"},
+     *     security={{"bearerAuth":{}}},
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Usuário autenticado com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="user", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="John Doe"),
+     *                 @OA\Property(property="email", type="string", format="email", example="john@example.com")
+     *             )
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=400,
+     *         description="Token inválido",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="error", type="string", example="Invalid token")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=404,
+     *         description="Usuário não encontrado",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="error", type="string", example="User not found")
+     *         )
+     *     )
+     * )
+     */
     public function getUser()
     {
         try {
@@ -38,6 +136,25 @@ class AuthController extends Controller
         return response()->json(compact('user'));
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/logout",
+     *     summary="Efetuar logout do usuário",
+     *     description="Invalida o token JWT do usuário autenticado, encerrando a sessão.",
+     *     tags={"Autenticação"},
+     *     security={{"bearerAuth":{}}},
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Logout realizado com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Successfully logged out")
+     *         )
+     *     )
+     * )
+     */
     public function logout()
     {
         JWTAuth::invalidate(JWTAuth::getToken());

--- a/app/Http/Controllers/CityController.php
+++ b/app/Http/Controllers/CityController.php
@@ -2,15 +2,45 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\ShowCityMedicsRequest;
 use App\Models\City;
 use App\Models\Medic;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class CityController extends Controller
 {
     /**
-     * Display the specified resource.
+     * @OA\Get(
+     *     path="/api/cidades",
+     *     summary="Listar todas as cidades",
+     *     description="Retorna uma lista de todas as cidades cadastradas.",
+     *     tags={"Cidades"},
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de cidades retornada com sucesso",
+     *
+     *         @OA\JsonContent(
+     *             type="array",
+     *
+     *             @OA\Items(
+     *
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="São Paulo")
+     *             )
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao listar cidades",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao listar cidades."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
      */
     public function index()
     {
@@ -29,38 +59,109 @@ class CityController extends Controller
         }
     }
 
-    public function show(ShowCityMedicsRequest $request, $id_cidade): JsonResponse
+    /**
+     * @OA\Get(
+     *     path="/api/cidades/{id_cidade}/medicos",
+     *     summary="Listar médicos de uma cidade específica",
+     *     description="Retorna uma lista de médicos cadastrados em uma cidade específica. Permite busca por nome.",
+     *     tags={"Médicos"},
+     *
+     *     @OA\Parameter(
+     *         name="id_cidade",
+     *         in="path",
+     *         description="ID da cidade",
+     *         required=true,
+     *
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *
+     *     @OA\Parameter(
+     *         name="nome",
+     *         in="query",
+     *         description="Parte do nome do médico para busca (ignora 'Dr.' e 'Dra.')",
+     *         required=false,
+     *
+     *         @OA\Schema(type="string", example="João")
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de médicos retornada com sucesso",
+     *
+     *         @OA\JsonContent(
+     *             type="array",
+     *
+     *             @OA\Items(
+     *
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Dr. João Silva"),
+     *                 @OA\Property(property="specialization", type="string", example="Cardiologista"),
+     *                 @OA\Property(property="city_id", type="integer", example=1),
+     *                 @OA\Property(property="created_at", type="string", format="date-time", example="2024-02-03T12:00:00Z"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time", example="2024-02-03T12:00:00Z")
+     *             )
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=404,
+     *         description="Cidade não encontrada",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Cidade não encontrada.")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao listar os médicos",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao listar os médicos."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
+     */
+    public function getMedicosByCidade(Request $request, $id_cidade)
     {
         try {
-            $city = City::findOrFail($id_cidade);
-            $medics = Medic::where('city_id', $id_cidade)->get();
-            if ($medics->isEmpty()) {
+            $city = City::find($id_cidade);
+
+            if (! $city) {
+                return response()->json(['message' => 'Cidade não encontrada.'], 404);
+            }
+
+            $query = Medic::where('city_id', $id_cidade);
+
+            if ($request->has('nome') && ! empty($request->input('nome'))) {
+                $nome = $request->input('nome');
+                $nameWithoutPrefix = preg_replace('/^Dr\. |^Dra\. /i', '', $nome);
+                $query->whereRaw("REPLACE(REPLACE(name, 'Dr. ', ''), 'Dra. ', '') LIKE ?", ["%$nameWithoutPrefix%"]);
+            }
+            $query->orderByRaw("REPLACE(REPLACE(name, 'Dr. ', ''), 'Dra. ', '') ASC");
+
+            $medicos = $query->get();
+
+            if ($medicos->isEmpty()) {
                 return response()->json([
                     'cidade' => $city->name,
                     'message' => 'Nenhum médico encontrado nesta cidade.',
-                ], 404);
+                ], 200);
             }
-            $medicosFormatados = $medics->map(function ($medic) {
-                return [
-                    'id' => $medic->id,
-                    'nome' => $medic->name,
-                    'especialidade' => $medic->specialization,
-                    'cidade_id' => $medic->city_id,
-                ];
-            });
 
-            return response()->json(
-                $medicosFormatados, 200);
-
-        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             return response()->json([
-                'message' => 'Cidade não encontrada.',
-            ], 404);
+                'cidade' => $city->name,
+                'medicos' => $medicos,
+            ], 200);
+
         } catch (\Exception $e) {
-            \Log::error('Erro ao listar médicos por cidade:', ['error' => $e->getMessage()]);
+            \Log::error('Erro ao listar os médicos:', ['error' => $e->getMessage()]);
 
             return response()->json([
-                'message' => 'Erro ao carregar médicos da cidade.',
+                'message' => 'Erro ao listar os médicos.',
                 'error' => $e->getMessage(),
             ], 500);
         }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,29 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+
+/**
+ * @OA\Info(
+ *     title="API de Consultas Médicas",
+ *     version="1.0.0",
+ *     description="Documentação da API para agendamento de consultas médicas.",
+ *
+ *     @OA\Contact(
+ *         email="lsouzapedroso@gmail.com"
+ *     )
+ * )
+ *
+ * @OA\SecurityScheme(
+ *     securityScheme="bearerAuth",
+ *     type="http",
+ *     scheme="bearer",
+ *     bearerFormat="JWT",
+ *     description="Insira o token JWT no formato: Bearer {token}"
+ * )
+ */
+class Controller
 {
-    //
+    use AuthorizesRequests, ValidatesRequests;
 }

--- a/app/Http/Controllers/MedicController.php
+++ b/app/Http/Controllers/MedicController.php
@@ -7,31 +7,132 @@ use App\Http\Requests\StoreMedicRequest;
 use App\Models\Medic;
 use App\Models\Patient;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class MedicController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * @OA\Get(
+     *     path="/api/medicos",
+     *     summary="Listar todos os médicos",
+     *     description="Retorna uma lista de todos os médicos cadastrados. Permite busca por nome.",
+     *     tags={"Médicos"},
+     *
+     *     @OA\Parameter(
+     *         name="nome",
+     *         in="query",
+     *         description="Parte do nome do médico para busca (ignora 'Dr.' e 'Dra.')",
+     *         required=false,
+     *
+     *         @OA\Schema(type="string", example="João")
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de médicos retornada com sucesso",
+     *
+     *         @OA\JsonContent(
+     *             type="array",
+     *
+     *             @OA\Items(
+     *
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Dr. João Silva"),
+     *                 @OA\Property(property="specialization", type="string", example="Cardiologista"),
+     *                 @OA\Property(property="city_id", type="integer", example=1),
+     *                 @OA\Property(property="created_at", type="string", format="date-time", example="2024-02-03T12:00:00Z"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time", example="2024-02-03T12:00:00Z")
+     *             )
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao listar os médicos",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao listar os médicos."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
      */
-    public function index()
+    public function index(Request $request)
     {
         try {
-            $medics = Medic::all();
+            $query = Medic::query();
 
-            return response()->json(
-                $medics, 200);
+            $columnName = 'name';
+
+            if ($request->has('nome') && ! empty($request->input('nome'))) {
+                $nome = $request->input('nome');
+
+                $nameWithoutPrefix = preg_replace('/^Dr\. |^Dra\. /i', '', $nome);
+
+                $query->whereRaw("REPLACE(REPLACE($columnName, 'Dr. ', ''), 'Dra. ', '') LIKE ?", ["%$nameWithoutPrefix%"]);
+            }
+            $query->orderByRaw("REPLACE(REPLACE($columnName, 'Dr. ', ''), 'Dra. ', '') ASC");
+            $medicos = $query->get();
+
+            return response()->json($medicos, 200);
         } catch (\Exception $e) {
-            \Log::error('Erro ao listar os medicos:', ['error' => $e->getMessage()]);
+            \Log::error('Erro ao listar os médicos:', ['error' => $e->getMessage()]);
 
             return response()->json([
-                'message' => 'Erro ao listar os medicos.',
+                'message' => 'Erro ao listar os médicos.',
                 'error' => $e->getMessage(),
             ], 500);
         }
     }
 
     /**
-     * Store a newly created resource in storage.
+     * @OA\Post(
+     *     path="/api/medicos",
+     *     summary="Cadastrar um novo médico",
+     *     description="Cadastra um novo médico no sistema.",
+     *     tags={"Médicos"},
+     *     security={{"bearerAuth":{}}},
+     *
+     *     @OA\RequestBody(
+     *         required=true,
+     *
+     *         @OA\JsonContent(
+     *             required={"nome", "especialidade", "cidade_id"},
+     *
+     *             @OA\Property(property="nome", type="string", example="Dr. João Silva"),
+     *             @OA\Property(property="especialidade", type="string", example="Cardiologia"),
+     *             @OA\Property(property="cidade_id", type="integer", example=1)
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=201,
+     *         description="Médico cadastrado com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="nome", type="string", example="Dr. João Silva"),
+     *             @OA\Property(property="especialidade", type="string", example="Cardiologia"),
+     *             @OA\Property(property="cidade_id", type="integer", example=1),
+     *             @OA\Property(property="created_at", type="string", format="date-time", example="2024-02-01T12:00:00Z"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time", example="2024-02-01T12:00:00Z"),
+     *             @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null)
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao cadastrar o médico",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao cadastrar o médico."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
      */
     public function store(StoreMedicRequest $request): JsonResponse
     {
@@ -63,20 +164,109 @@ class MedicController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * @OA\Get(
+     *     path="/api/medicos/{id_medico}/pacientes",
+     *     summary="Listar pacientes de um médico",
+     *     description="Retorna todos os pacientes que possuem consultas agendadas e/ou realizadas com o médico. Permite filtros opcionais.",
+     *     tags={"Médicos"},
+     *     security={{ "bearerAuth":{} }},
+     *
+     *     @OA\Parameter(
+     *         name="id_medico",
+     *         in="path",
+     *         description="ID do médico",
+     *         required=true,
+     *
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *
+     *     @OA\Parameter(
+     *         name="apenas-agendadas",
+     *         in="query",
+     *         description="Se verdadeiro, retorna apenas consultas futuras",
+     *         required=false,
+     *
+     *         @OA\Schema(type="boolean", example=true)
+     *     ),
+     *
+     *     @OA\Parameter(
+     *         name="nome",
+     *         in="query",
+     *         description="Nome do paciente para busca",
+     *         required=false,
+     *
+     *         @OA\Schema(type="string", example="Carlos")
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de pacientes retornada com sucesso",
+     *
+     *         @OA\JsonContent(
+     *             type="array",
+     *
+     *             @OA\Items(
+     *
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="nome", type="string", example="Carlos Souza"),
+     *                 @OA\Property(property="cpf", type="string", example="123.456.789-00"),
+     *                 @OA\Property(property="celular", type="string", example="(11) 98765-4321"),
+     *                 @OA\Property(property="consulta", type="object",
+     *                     @OA\Property(property="id", type="integer", example=10),
+     *                     @OA\Property(property="data", type="string", format="date-time", example="2024-02-05T10:00:00Z"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=404,
+     *         description="Médico não encontrado",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Médico não encontrado.")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao listar pacientes",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao listar pacientes."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
      */
-    public function show(ShowMedicPatientRequest $request, $id_medico): JsonResponse
+    public function listMedicPatient(ShowMedicPatientRequest $request, $id_medico): JsonResponse
     {
         try {
             $medic = Medic::findOrFail($id_medico);
 
-            $patients = Patient::whereHas('appointments', function ($query) use ($id_medico) {
+            $query = Patient::whereHas('appointments', function ($query) use ($id_medico, $request) {
                 $query->where('medic_id', $id_medico);
-            })
-                ->with(['appointments' => function ($query) use ($id_medico) {
-                    $query->where('medic_id', $id_medico)->select('id', 'patient_id', 'date', 'created_at', 'updated_at', 'deleted_at');
-                }])
-                ->get();
+
+                if ($request->has('apenas-agendadas') && filter_var($request->input('apenas-agendadas'), FILTER_VALIDATE_BOOLEAN)) {
+                    $query->where('date', '>=', now());
+                }
+            });
+
+            if ($request->has('nome') && ! empty($request->input('nome'))) {
+                $nome = $request->input('nome');
+                $query->where('name', 'LIKE', "%$nome%");
+            }
+
+            $patients = $query->with(['appointments' => function ($query) use ($id_medico) {
+                $query->where('medic_id', $id_medico)
+                    ->select('id', 'patient_id', 'date', 'created_at', 'updated_at', 'deleted_at')
+                    ->orderBy('date', 'asc');
+            }])->get();
 
             if ($patients->isEmpty()) {
                 return response()->json([
@@ -94,18 +284,19 @@ class MedicController extends Controller
                     'created_at' => $patient->created_at,
                     'updated_at' => $patient->updated_at,
                     'deleted_at' => $patient->deleted_at,
-                    'consulta' => $patient->appointments->isNotEmpty() ? [
-                        'id' => $patient->appointments->first()->id,
-                        'data' => $patient->appointments->first()->date,
-                        'created_at' => $patient->appointments->first()->created_at,
-                        'updated_at' => $patient->appointments->first()->updated_at,
-                        'deleted_at' => $patient->appointments->first()->deleted_at,
-                    ] : null,
+                    'consulta' => $patient->appointments->map(function ($appointment) {
+                        return [
+                            'id' => $appointment->id,
+                            'data' => $appointment->date,
+                            'created_at' => $appointment->created_at,
+                            'updated_at' => $appointment->updated_at,
+                            'deleted_at' => $appointment->deleted_at,
+                        ];
+                    }),
                 ];
             });
 
-            return response()->json(
-                $formattedPatients, 200);
+            return response()->json($formattedPatients, 200);
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             return response()->json([
                 'message' => 'Médico não encontrado.',

--- a/app/Http/Controllers/PatientController.php
+++ b/app/Http/Controllers/PatientController.php
@@ -10,28 +10,52 @@ use Illuminate\Http\JsonResponse;
 class PatientController extends Controller
 {
     /**
-     * Display the specified resource.
-     */
-    public function index()
-    {
-        try {
-            $patients = Patient::all();
-
-            return response()->json([
-                $patients,
-            ], 200);
-        } catch (\Exception $e) {
-            \Log::error('Erro ao listar paciente:', ['error' => $e->getMessage()]);
-
-            return response()->json([
-                'message' => 'Erro ao listar o paciente.',
-                'error' => $e->getMessage(),
-            ], 500);
-        }
-    }
-
-    /**
-     * Store a newly created resource in storage.
+     * @OA\Post(
+     *     path="/api/pacientes",
+     *     summary="Cadastrar um novo paciente",
+     *     description="Cadastra um novo paciente no sistema.",
+     *     tags={"Pacientes"},
+     *     security={{"bearerAuth":{}}},
+     *
+     *     @OA\RequestBody(
+     *         required=true,
+     *
+     *         @OA\JsonContent(
+     *             required={"nome", "cpf", "celular"},
+     *
+     *             @OA\Property(property="nome", type="string", example="Maria Souza"),
+     *             @OA\Property(property="cpf", type="string", example="123.456.789-00"),
+     *             @OA\Property(property="celular", type="string", example="+55 11 98765-4321")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=201,
+     *         description="Paciente cadastrado com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="nome", type="string", example="Maria Souza"),
+     *             @OA\Property(property="cpf", type="string", example="849.570.310-61"),
+     *             @OA\Property(property="celular", type="string", example="+55 11 98765-4321"),
+     *             @OA\Property(property="created_at", type="string", format="date-time", example="2024-02-01T12:00:00Z"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time", example="2024-02-01T12:00:00Z"),
+     *             @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null)
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao cadastrar o paciente",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao cadastrar o paciente."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
      */
     public function store(StorePatientRequest $request): JsonResponse
     {
@@ -63,7 +87,80 @@ class PatientController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * @OA\Put(
+     *     path="/api/pacientes/{id}",
+     *     summary="Atualizar informações de um paciente",
+     *     description="Atualiza os dados de um paciente existente.",
+     *     tags={"Pacientes"},
+     *     security={{"bearerAuth":{}}},
+     *
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="ID do paciente",
+     *
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *
+     *     @OA\RequestBody(
+     *         required=true,
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="nome", type="string", example="Maria Souza"),
+     *             @OA\Property(property="celular", type="string", example="+55 11 98765-4321")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paciente atualizado com sucesso",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="nome", type="string", example="Maria Souza"),
+     *             @OA\Property(property="cpf", type="string", example="123.456.789-00"),
+     *             @OA\Property(property="celular", type="string", example="+55 11 98765-4321"),
+     *             @OA\Property(property="created_at", type="string", format="date-time", example="2024-02-01T12:00:00Z"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time", example="2024-02-01T12:00:00Z"),
+     *             @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null)
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=400,
+     *         description="Nenhuma informação foi fornecida para atualização",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Nenhuma informação foi fornecida para atualização.")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=404,
+     *         description="Paciente não encontrado",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Paciente não encontrado."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=500,
+     *         description="Erro ao atualizar o paciente",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="Erro ao atualizar o paciente."),
+     *             @OA\Property(property="error", type="string", example="Mensagem detalhada do erro")
+     *         )
+     *     )
+     * )
      */
     public function update(UpdatePatientRequest $request, $id_paciente)
     {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "darkaonline/l5-swagger": "^8.6",
         "laravel/framework": "^11.31",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d5fae9e11fe547efa8182a3e05361b2",
+    "content-hash": "219b017d888b7d9cb4c25b328f6ed779",
     "packages": [
         {
             "name": "brick/math",
@@ -136,6 +136,86 @@
             "time": "2024-02-09T16:56:22+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "8.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "b37695804b786c04ab4077ceb6c0f2907ccd0153"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/b37695804b786c04ab4077ceb6c0f2907ccd0153",
+                "reference": "b37695804b786c04ab4077ceb6c0f2907ccd0153",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^11.0 || ^10.0 || ^9.0 || >=8.40.0 || ^7.0",
+                "php": "^7.2 || ^8.0",
+                "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^3.2.0 || ^4.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^10.0 || ^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/8.6.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-28T06:29:43+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -209,6 +289,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -580,6 +736,89 @@
                 }
             ],
             "time": "2023-10-12T05:21:21+00:00"
+        },
+        {
+            "name": "giggsey/libphonenumber-for-php-lite",
+            "version": "8.13.54",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/libphonenumber-for-php-lite.git",
+                "reference": "23f904bf60b40fe0fb9f4ade0e8321654610fcc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/23f904bf60b40fe0fb9f4ade0e8321654610fcc8",
+                "reference": "23f904bf60b40fe0fb9f4ade0e8321654610fcc8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "conflict": {
+                "giggsey/libphonenumber-for-php": "*"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^3.12",
+                "infection/infection": "^0.28",
+                "pear/pear-core-minimal": "^1.10.11",
+                "pear/pear_exception": "^1.0.2",
+                "pear/versioncontrol_git": "^0.7",
+                "phing/phing": "^2.17.4",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.2",
+                "phpunit/phpunit": "^10.5",
+                "symfony/console": "^6.0",
+                "symfony/var-exporter": "^6.0"
+            },
+            "suggest": {
+                "giggsey/libphonenumber-for-php": "Use libphonenumber-for-php for geocoding, carriers, timezones and matching"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "libphonenumber\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/src/data/",
+                    "/src/carrier/data/",
+                    "/src/geocoding/data/",
+                    "/src/timezone/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "A lite version of giggsey/libphonenumber-for-php, which is a PHP Port of Google's libphonenumber",
+            "homepage": "https://github.com/giggsey/libphonenumber-for-php-lite",
+            "keywords": [
+                "geocoding",
+                "geolocation",
+                "libphonenumber",
+                "mobile",
+                "phonenumber",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/giggsey/libphonenumber-for-php-lite/issues",
+                "source": "https://github.com/giggsey/libphonenumber-for-php-lite"
+            },
+            "time": "2025-01-31T14:48:31+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -1518,6 +1757,57 @@
                 "source": "https://github.com/laravel/tinker/tree/v2.10.1"
             },
             "time": "2025-01-27T14:24:01+00:00"
+        },
+        {
+            "name": "laravellegends/pt-br-validator",
+            "version": "11.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LaravelLegends/pt-br-validator.git",
+                "reference": "ab89fcb32661bc1a95c5836489ddc68f61a95d34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LaravelLegends/pt-br-validator/zipball/ab89fcb32661bc1a95c5836489ddc68f61a95d34",
+                "reference": "ab89fcb32661bc1a95c5836489ddc68f61a95d34",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "phpunit/phpunit": "^8.3 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LaravelLegends\\PtBrValidator\\ValidatorProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LaravelLegends\\PtBrValidator\\": "src/pt-br-validator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wallace de Souza Vizerra",
+                    "email": "wallacemaxters@gmail.com"
+                }
+            ],
+            "description": "Uma biblioteca contendo validações de formatos Brasileiros, para o Laravel",
+            "support": {
+                "issues": "https://github.com/LaravelLegends/pt-br-validator/issues",
+                "source": "https://github.com/LaravelLegends/pt-br-validator/tree/11.0.0"
+            },
+            "time": "2024-03-18T20:18:50+00:00"
         },
         {
             "name": "lcobucci/clock",
@@ -2786,6 +3076,126 @@
             "time": "2024-07-20T21:41:07+00:00"
         },
         {
+            "name": "propaganistas/laravel-phone",
+            "version": "5.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Propaganistas/Laravel-Phone.git",
+                "reference": "2172362ae5714ddc397d9df96a44b82bd125631a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Propaganistas/Laravel-Phone/zipball/2172362ae5714ddc397d9df96a44b82bd125631a",
+                "reference": "2172362ae5714ddc397d9df96a44b82bd125631a",
+                "shasum": ""
+            },
+            "require": {
+                "giggsey/libphonenumber-for-php-lite": "^8.13.35",
+                "illuminate/contracts": "^10.0|^11.0",
+                "illuminate/support": "^10.0|^11.0",
+                "illuminate/validation": "^10.0|^11.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "orchestra/testbench": "*",
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Propaganistas\\LaravelPhone\\PhoneServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Propaganistas\\LaravelPhone\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Propaganistas",
+                    "email": "Propaganistas@users.noreply.github.com"
+                }
+            ],
+            "description": "Adds phone number functionality to Laravel based on Google's libphonenumber API.",
+            "keywords": [
+                "laravel",
+                "libphonenumber",
+                "phone",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/Propaganistas/Laravel-Phone/issues",
+                "source": "https://github.com/Propaganistas/Laravel-Phone/tree/5.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Propaganistas",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-27T11:45:47+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3500,6 +3910,67 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.18.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "e322ecd6ba8a5a3ff1ebbb3692aa2334050f6196"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/e322ecd6ba8a5a3ff1ebbb3692aa2334050f6196",
+                "reference": "e322ecd6ba8a5a3ff1ebbb3692aa2334050f6196",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.18.3"
+            },
+            "time": "2025-01-28T12:46:44+00:00"
         },
         {
             "name": "symfony/clock",
@@ -5730,6 +6201,78 @@
             "time": "2025-01-17T11:39:41+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "ac238f173df0c9c1120f862d0f599e17535a87ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ac238f173df0c9c1120f862d0f599e17535a87ec",
+                "reference": "ac238f173df0c9c1120f862d0f599e17535a87ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-07T12:55:42+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.3.0",
             "source": {
@@ -6083,6 +6626,87 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "4.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^1.7 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17 || 3.62.0",
+                "phpstan/phpstan": "^1.6",
+                "phpunit/phpunit": ">=8",
+                "vimeo/psalm": "^4.23"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.7 || ^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/4.11.1"
+            },
+            "time": "2024-10-15T19:20:02+00:00"
         }
     ],
     "packages-dev": [
@@ -8238,78 +8862,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ac238f173df0c9c1120f862d0f599e17535a87ec"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ac238f173df0c9c1120f862d0f599e17535a87ec",
-                "reference": "ac238f173df0c9c1120f862d0f599e17535a87ec",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.2.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-01-07T12:55:42+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/routes/api/authenticated.php
+++ b/routes/api/authenticated.php
@@ -25,9 +25,8 @@ Route::middleware([Middleware::class])->group(function () {
     Route::post('logout', [AuthController::class, 'logout']);
 
     Route::post('/medicos', [MedicController::class, 'store']);
-    Route::put('/medicos/{{id_medico}}/pacientes', [MedicController::class, 'show']);
     Route::post('/medicos/consulta', [AppointmentsController::class, 'store']);
-    Route::get('/medicos/{id_medico}/pacientes', [MedicController::class, 'show']);
+    Route::get('/medicos/{id_medico}/pacientes', [MedicController::class, 'listMedicPatient']);
 
     Route::get('/pacientes', [PatientController::class, 'store']);
     Route::post('/pacientes', [PatientController::class, 'store']);

--- a/routes/api/unauthenticated.php
+++ b/routes/api/unauthenticated.php
@@ -28,6 +28,6 @@ Route::get('/info', function () {
 });
 
 Route::get('/cidades', [CityController::class, 'index']);
-Route::get('/cidades/{id_cidade}/medicos', [CityController::class, 'show']);
+Route::get('/cidades/{id_cidade}/medicos', [CityController::class, 'getMedicosByCidade']);
 
 Route::get('/medicos', [MedicController::class, 'index']);


### PR DESCRIPTION
… pacientes

- Adicionada documentação OpenAPI (Swagger) para o endpoint `/medicos/{id_medico}/pacientes`
- Especificados os parâmetros opcionais `apenas-agendadas` e `nome` no Swagger
- Ajustado o retorno para exibir apenas um objeto "consulta" ao invés de um array
- Garantido que a primeira consulta do paciente seja retornada, ordenada por data crescente
- Adicionado suporte para retornar `consulta: null` caso o paciente não tenha consultas associadas
- Refatoração do código para melhorar legibilidade e performance

---
-close #12 